### PR TITLE
some small changes to code blocks style

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@
 
 title: Bayesian Modeling and Computation in Python
 author: Martin, Kumar, Lao
+exclude_patterns: [_build, Thumbs.db, .DS_Store, "**.ipynb_checkpoints", "**/README.md"]
 # logo: logo.png
 execute:
   execute_notebooks         : off  # Whether to execute notebooks at build time. Must be one of ("auto", "force", "cache", "off")
@@ -15,6 +16,8 @@ execute:
   stderr_output             : show  # One of 'show', 'remove', 'remove-warn', 'warn', 'error', 'severe'
 
 sphinx:
+    extra_extensions:
+      - sphinx_codeautolink
     config:
       html_theme_options:
         use_download_button: false
@@ -23,6 +26,23 @@ sphinx:
         use_repository_button: true
         search_bar_text: Search this book...
         home_page_in_toc: true
+      intersphinx_mapping:
+        arviz:
+          - https://arviz-devs.github.io/arviz/
+          - null
+        numpy:
+          - https://numpy.org/doc/stable
+          - null
+        matplotlib:
+          - https://matplotlib.org/stable
+          - null
+        scipy:
+          - https://docs.scipy.org/doc/scipy
+          - null
+      codeautolink_autodoc_inject: false
+      codeautolink_concat_default: true
+      codeautolink_global_preface: "import arviz as az; import numpy as np; import matplotlib.pyplot as plt; import scipy.stats as stats"
+
 
 bibtex_bibfiles:
     - bibtex.bib

--- a/markdown/chp_01.md
+++ b/markdown/chp_01.md
@@ -127,7 +127,7 @@ us with a general recipe to estimate the value of the parameter
 $\boldsymbol{\theta}$ given that we have observed some data
 $\boldsymbol{Y}$:
 
-```{math} 
+```{math}
 :label: eq:posterior_dist
 \underbrace{p(\boldsymbol{\theta} \mid \boldsymbol{Y})}_{\text{posterior}} = \frac{\overbrace{p(\boldsymbol{Y} \mid \boldsymbol{\theta})}^{\text{likelihood}}\; \overbrace{p(\boldsymbol{\theta})}^{\text{prior}}}{\underbrace{{p(\boldsymbol{Y})}}_{\text{marginal likelihood}}}
 
@@ -175,7 +175,7 @@ normalizing constant. Unfortunately, difficulties arise from the need to
 compute the normalizing constant $p(\boldsymbol{Y})$. This is easier to
 see if we write the marginal likelihood as:
 
-```{math} 
+```{math}
 :label: eq:marginal_likelihood
 {p(\boldsymbol{Y}) = \int_{\boldsymbol{\Theta}} p(\boldsymbol{Y} \mid \boldsymbol{\theta})p(\boldsymbol{\theta}) d\boldsymbol{\theta}}
 
@@ -192,7 +192,7 @@ numerical methods that can help us with this challenge if used properly.
 As the marginal likelihood is not generally computed, it is very common
 to see Bayes' theorem expressed as a proportionality:
 
-```{math} 
+```{math}
 :label: eq:proportional_bayes
 \underbrace{p(\boldsymbol{\theta} \mid \boldsymbol{Y})}_{\text{posterior}} \propto \overbrace{p(\boldsymbol{Y} \mid \boldsymbol{\theta})}^{\text{likelihood}}\; \overbrace{p(\boldsymbol{\theta})}^{\text{prior}}
 ```
@@ -231,7 +231,7 @@ have a healthy quota of skepticism about our data, models, and results.
 To make this more explicit, we may want to express Bayes' theorem in a
 more nuanced way:
 
-```{math} 
+```{math}
 p(\boldsymbol{\theta} \mid  \boldsymbol{Y}, M) \propto  p(\boldsymbol{Y} \mid \boldsymbol{\theta}, M) \; p(\boldsymbol{\theta}, M)
 ```
 
@@ -242,7 +242,7 @@ Having said that, once we have a posterior distribution we can use it to
 derive other quantities of interest. This is generally done by computing
 expectations, for example:
 
-```{math} 
+```{math}
 :label: eq:posterior_expectation
 J = \int f(\boldsymbol{\theta}) \; p(\boldsymbol{\theta} \mid \boldsymbol{Y}) \; d\boldsymbol{\theta}
 
@@ -251,7 +251,7 @@ J = \int f(\boldsymbol{\theta}) \; p(\boldsymbol{\theta} \mid \boldsymbol{Y}) \;
 If $f$ is the identity function $J$ will turn out be the mean [^7] of
 $\boldsymbol{\theta}.$:
 
-```{math} 
+```{math}
 \bar{\boldsymbol{\theta}} = \int_{\boldsymbol{\Theta}} \boldsymbol{\theta}  p(\boldsymbol{\theta} \mid \boldsymbol{Y})  d\boldsymbol{\theta}
 ```
 
@@ -260,7 +260,7 @@ but it is not the only one. Besides making inferences about parameter
 values, we may want to make inferences about data. This can be done by
 computing the **prior predictive distribution**:
 
-```{math} 
+```{math}
 :label: eq:prior_pred_dist
 p(\boldsymbol{Y}^\ast) =  \int_{\boldsymbol{\Theta}} p(\boldsymbol{Y^\ast} \mid \boldsymbol{\theta}) \; p(\boldsymbol{\theta}) \; d\boldsymbol{\theta}
 
@@ -305,7 +305,7 @@ Iterate if necessary.
 
 Another useful quantity to compute is the **posterior predictive distribution**:
 
-```{math} 
+```{math}
 :label: eq:post_pred_dist
 p(\tilde{\boldsymbol{Y}} \mid \boldsymbol{Y}) = \int_{\boldsymbol{\Theta}} p(\tilde{\boldsymbol{Y}} \mid \boldsymbol{\theta}) \, p(\boldsymbol{\theta} \mid \boldsymbol{Y}) \, d\boldsymbol{\theta}
 
@@ -385,9 +385,9 @@ The Metropolis-Hasting algorithm is defined as follows:
 
 3.  Compute the probability of accepting the new value as:
 
-    ```{math} 
+    ```{math}
     :label: acceptance_prob
-    p_a (x_{i + 1} \mid x_i) = \min \left (1, \frac{p(x_{i + 1}) \; 
+    p_a (x_{i + 1} \mid x_i) = \min \left (1, \frac{p(x_{i + 1}) \;
     q(x_i \mid x_{i + 1})} {p(x_i) \; q (x_{i + 1} \mid x_i)} \right)
 
     ```
@@ -427,7 +427,7 @@ statistics, because it is a simple model that we can solve and compute
 with ease. In statistical notation we can write the Beta-Binomial models
 as:
 
-```{math} 
+```{math}
 :label: eq:beta_binomial
 
 \begin{split}
@@ -479,16 +479,17 @@ algorithm:
 ```{code-block} python
 :name: metropolis_hastings
 :caption: metropolis_hastings
+:linenos:
 n_iters = 1000
 can_sd = 0.05
 α = β =  1
-θ = 0.5 
+θ = 0.5
 trace = {"θ":np.zeros(n_iters)}
 p2 = post(θ, Y, α, β)
 
 for iter in range(n_iters):
     θ_can = stats.norm(θ, can_sd).rvs(1)
-    p1 = post(θ_can, Y, α, β)  
+    p1 = post(θ_can, Y, α, β)
     pa = p1 / p2
 
     if pa > stats.uniform(0, 1).rvs(1):
@@ -502,7 +503,7 @@ At line 9 of Code Block [metropolis_hastings](metropolis_hastings) we generate a
 distribution by sampling from a Normal distribution with standard
 deviation `can_sd`. At line 10 we evaluate the posterior at the new
 generated value `θ_can` and at line 11 we compute the probability of
-acceptance. At line 20 we save a value of `θ` in the `trace` array.
+acceptance. At line 17 we save a value of `θ` in the `trace` array.
 Whether this value is a new one or we repeat the previous one, it will
 depends on the result of the comparison at line 13.
 
@@ -570,7 +571,7 @@ will use the Python package ArviZ {cite:p}`Kumar2019` to compute these
 statistics:
 
 ```python
-az.summary(trace, kind="stats", round_to=2))
+az.summary(trace, kind="stats", round_to=2)
 ```
 
 ```{list-table} Posterior summary
@@ -649,10 +650,10 @@ Equation {eq}`eq:beta_binomial` using PyMC3:
 with pm.Model() as model:
     # Specify the prior distribution of unknown parameter
     θ = pm.Beta("θ", alpha=1, beta=1)
-    
+
     # Specify the likelihood distribution and condition on the observed data
     y_obs = pm.Binomial("y_obs", n=1, p=θ, observed=Y)
-    
+
     # Sample from the posterior distribution
     idata = pm.sample(1000, return_inferencedata=True)
 ```
@@ -819,20 +820,20 @@ model.
 As the name suggests, the conjugate prior for the binomial distribution
 is the Beta distribution:
 
-```{math} 
+```{math}
 p(\theta \mid Y) \propto \overbrace{\frac{N!}{y!(N-y)!} \theta^y (1 - \theta)^{N-y}}^{\text{binomial-likelihood}} \: \overbrace{\frac{\Gamma(\alpha+\beta)}{\Gamma(\alpha)\Gamma(\beta)}\, \theta^{\alpha-1}(1-\theta)^{\beta-1}}^{\text{beta.prior}}
 ```
 
 Because all the terms not depending on $\theta$ are constant we can drop
 them and we get:
 
-```{math} 
+```{math}
 p(\theta \mid Y) \propto \overbrace{\theta^y (1 - \theta)^{N-y}}^{\text{binomial-likelihood}} \: \overbrace{ \theta^{\alpha-1}(1-\theta)^{\beta-1}}^{\text{beta.prior}}
 ```
 
 Reordering:
 
-```{math} 
+```{math}
 :label: eq:kernel_beta
 p(\theta \mid Y) \propto \theta^{\alpha-1+y}(1-\theta)^{\beta-1+N-y}
 
@@ -846,7 +847,7 @@ distribution, thus by adding the normalization constant of a Beta
 distribution we arrive to the conclusion that the posterior distribution
 for a Beta-Binomial model is:
 
-```{math} 
+```{math}
 :label: eq:beta_posterior
 p(\theta \mid Y) \propto \frac{\Gamma(\alpha_{post}+\beta_{post})}{\Gamma(\alpha_{post})\Gamma(\beta_{post})} \theta^{\alpha_{post}-1}(1-\theta)^{\beta_{post}-1} = \text{Beta}(\alpha_{post}, \beta_{post})
 
@@ -915,13 +916,13 @@ $\hat \theta = \frac{y}{n}$.
 The mean of the Beta distribution is $\frac{\alpha}{\alpha + \beta}$,
 thus the prior mean is:
 
-```{math} 
+```{math}
 \mathbb{E}[\theta]  = \frac{\alpha}{\alpha + \beta}
 ```
 
 and the posterior mean is:
 
-```{math} 
+```{math}
 :label: eq:beta_binom_mean
 \mathbb{E}[\theta \mid Y]  = \frac{\alpha + y}{\alpha + \beta + n}
 
@@ -938,7 +939,7 @@ choose for $\alpha$ and $\beta$.
 
 For the Beta Binomial model the posterior mode is:
 
-```{math} 
+```{math}
 :label: eq:beta_binom_mode
 \operatorname*{argmax}_{\theta}{[\theta \mid Y]}  = \frac{\alpha + y - 1}{\alpha + \beta + n - 2}
 
@@ -1008,15 +1009,15 @@ posteriors that are coherent.
 
 For the one-dimensional case JP for $\theta$ is
 
-```{math} 
+```{math}
 :label: eq:Jeffreys_prior0
-p(\theta) \propto \sqrt{I(\theta)}   
+p(\theta) \propto \sqrt{I(\theta)}
 
 ```
 
 where $I(\theta)$ is the expected Fisher information:
 
-```{math} 
+```{math}
 :label: eq:Jeffreys_prior
 I(\theta) = - \mathbb{E_{Y}}\left[\frac{d^2}{d\theta^2} \log p(Y \mid \theta)\right]
 
@@ -1031,7 +1032,7 @@ For a detailed derivation of the JPs for both Alice and Bob problem see
 [Jeffrey\'s_prior_derivation](Jeffrey's_prior_derivation). If you
 want to skip those details here we have the JP for Alice:
 
-```{math} 
+```{math}
 \begin{aligned}
 p(\theta) \propto \theta^{-0.5} (1-\theta)^{-0.5}\end{aligned}
 ```
@@ -1042,7 +1043,7 @@ Which is a u-shaped distribution as shown in the left-top panel of
 
 For Bob the JP is:
 
-```{math} 
+```{math}
 :label: fig:bob_prior
 p(\kappa) \propto \kappa^{-0.5} (1 + \kappa)^{-1}
 
@@ -1522,7 +1523,7 @@ exercise, try by expanding Equation {eq}`acceptance_prob`.
 **1M15.** In the following definition of a probabilistic
 model, identify the prior, the likelihood, and the posterior:
 
-```{math} 
+```{math}
 \begin{split}
 Y \sim \mathcal{N}(\mu, \sigma)\\
 \mu \sim \mathcal{N}(0, 1)\\

--- a/markdown/chp_02.md
+++ b/markdown/chp_02.md
@@ -106,7 +106,7 @@ decide to use a geometric model [^4]. Following the sketch in
 {numref}`fig:football_sketch` and a little bit of trigonometry we come
 up with the following formula for the probability of scoring a goal:
 
-```{math} 
+```{math}
 :label: eq:geometric_football
 p\left(|\alpha| < \tan^{-1}\left(\frac{L}{x}\right)\right) = 2\Phi\left(\frac{\tan^{-1}\left(\frac{L}{x}\right)}{\sigma}\right) - 1
 
@@ -135,7 +135,7 @@ football. As good Bayesians, when we do not know a quantity, we assign a
 prior to it and then try to build a Bayesian model, for example, we
 could write:
 
-```{math} 
+```{math}
 :label: eq:geometric_model
 \begin{split}
 \sigma &= \mathcal{HN}(\sigma_{\sigma}) \\
@@ -268,10 +268,10 @@ Posterior predictive checks are not restricted to plots. We can also
 perform numerical tests {cite:p}`GelmanBayesianDataAnalysis2013`. One way of
 doing this is by computing:
 
-```{math} 
+```{math}
 :label: eq:post_pred_test_quantity
 p_{B} = p(T_{sim} \leq T_{obs} \mid \tilde Y)
-    
+
 ```
 
 where $p_{B}$ is a Bayesian p-value and is defined as the probability
@@ -470,14 +470,14 @@ sample.
 
 ```python
 good_chains = stats.beta.rvs(2, 5,size=(2, 2000))
-bad_chains0 = np.random.normal(np.sort(good_chains, axis=None), 0.05, 
+bad_chains0 = np.random.normal(np.sort(good_chains, axis=None), 0.05,
                                size=4000).reshape(2, -1)
 
 bad_chains1 = good_chains.copy()
 for i in np.random.randint(1900, size=4):
     bad_chains1[i%2:,i:i+100] = np.random.beta(i, 950, size=100)
-    
-chains = {"good_chains":good_chains, 
+
+chains = {"good_chains":good_chains,
           "bad_chains0":bad_chains0,
           "bad_chains1":bad_chains1}
 ```
@@ -517,7 +517,9 @@ Using ArviZ we can compute the effective sample size for the mean with
 
 ```python
 az.ess(chains)
+```
 
+```none
 <xarray.Dataset>
 Dimensions:      ()
 Data variables:
@@ -633,7 +635,9 @@ function
 
 ```python
 az.rhat(chains)
+```
 
+```none
 <xarray.Dataset>
 Dimensions:      ()
 Data variables:
@@ -673,7 +677,9 @@ Using ArviZ we can compute the MCSE with the function `az.mcse()`
 
 ```python
 az.mcse(chains)
+```
 
+```none
 <xarray.Dataset>
 Dimensions:      ()
 Data variables:
@@ -732,7 +738,7 @@ az.summary(chains, kind="diagnostics")
   - 0.013
   - 111.0
   - 105.0
-  - 1.03 
+  - 1.03
 ```
 
 
@@ -1109,10 +1115,10 @@ shown that the logarithmic scoring rule has very nice theoretical
 properties {cite:p}`gneiting_2007`, and thus is widely used. Under a Bayesian
 setting the log scoring rule can be computed as.
 
-```{math} 
+```{math}
 :label: eq:elpd
 \text{ELPD} = \sum_{i=1}^{n} \int p_t(\tilde y_i) \; \log p(\tilde y_i \mid y_i) \; d\tilde y_i
-    
+
 ```
 
 where $p_t(\tilde y_i)$ is distribution of the true data-generating
@@ -1129,10 +1135,10 @@ For real problems we do not know $p_t(\tilde y_i)$ and thus the ELPD as
 defined in Equation {eq}`eq:elpd` is of no immediate use, in practice we
 can instead compute:
 
-```{math} 
+```{math}
 :label: eq:elpd_practice
 \sum_{i=1}^{n} \log \int \ p(y_i \mid \boldsymbol{\theta}) \; p(\boldsymbol{\theta} \mid y) d\boldsymbol{\theta}
-    
+
 ```
 
 The quantity defined by Equation {eq}`eq:elpd_practice` (or that
@@ -1166,11 +1172,11 @@ Leave-one-out cross-validation (LOO-CV) is a particular type of
 cross-validation when the data excluded is a single data-point. The ELPD
 computed using LOO-CV is $\text{ELPD}_\text{LOO-CV}$:
 
-```{math} 
+```{math}
 :label: eq:elpd_loo_cv
 \text{ELPD}_\text{LOO-CV} = \sum_{i=1}^{n} \log
     \int \ p(y_i \mid \boldsymbol{\theta}) \; p(\boldsymbol{\theta} \mid y_{-i}) d\boldsymbol{\theta}
-    
+
 ```
 
 Computing Equation {eq}`eq:elpd_loo_cv` can easily become too costly as
@@ -1531,7 +1537,7 @@ in {ref}`posterior_pd` with the function
 LOO-PIT is obtained by comparing the observed data $y$ to posterior
 predicted data $\tilde y$. The comparison is done point-wise. We have:
 
-```{math} 
+```{math}
 p_i = P(\tilde y_i \leq y_i \mid y_{-i})
 ```
 
@@ -1578,10 +1584,10 @@ problematic in practice (see
 alternative is to use the values of LOO to estimate weights for each
 model. We can do this by using the following formula:
 
-```{math} 
+```{math}
 :label: eq_pseudo_avg
 w_i = \frac {e^{-\Delta_i }} {\sum_j^k e^{-\Delta_j }}
-    
+
 ```
 
 where $\Delta_i$ is the difference between the $i$ value of LOO and the
@@ -1606,10 +1612,10 @@ models in a meta-model in such a way that we minimize the divergence
 between the meta-model and the *true* generating model. When using a
 logarithmic scoring rule this is equivalently to compute:
 
-```{math} 
+```{math}
 :label: eq_stacking
 \max_{n} \frac{1}{n} \sum_{i=1}^{n}log\sum_{j=1}^{k} w_j p(y_i \mid y_{-i}, M_j)
-    
+
 ```
 
 where $n$ is the number of data points and $k$ the number of models. To

--- a/markdown/chp_03.md
+++ b/markdown/chp_03.md
@@ -103,11 +103,11 @@ estimates of uncertainty is by using Bayesian methods. In order to do so
 we need to conjecture a relationship of observations to parameters as
 example:
 
-```{math} 
+```{math}
 :label: eq:gaussian_bayes
-\overbrace{p(\mu, \sigma \mid Y)}^{Posterior} \propto \overbrace{\mathcal{N}(Y \mid \mu, \sigma)}^{Likelihood}\;  \overbrace{\underbrace{\mathcal{N}(4000, 3000)}_{\mu} 
+\overbrace{p(\mu, \sigma \mid Y)}^{Posterior} \propto \overbrace{\mathcal{N}(Y \mid \mu, \sigma)}^{Likelihood}\;  \overbrace{\underbrace{\mathcal{N}(4000, 3000)}_{\mu}
      \underbrace{\mathcal{H}\text{T}(100, 2000)}_{\sigma}}^{Prior}
-    
+
 ```
 
 Equation {eq}`eq:gaussian_bayes` is a restatement of Equation
@@ -257,7 +257,7 @@ with pm.Model() as model_penguin_mass_all_species:
     # Note the addition of the shape parameter
     σ = pm.HalfStudentT("σ", 100, 2000, shape=3)
     μ = pm.Normal("μ", 4000, 3000, shape=3)
-    mass = pm.Normal("mass", 
+    mass = pm.Normal("mass",
                      mu=μ[all_species.codes],
                      sigma=σ[all_species.codes],
                      observed=penguins["body_mass_g"])
@@ -526,7 +526,7 @@ inf_data_model_penguin_mass_all_species2 = az.from_dict(
     posterior={
         # TFP mcmc returns (num_samples, num_chains, ...), we swap
         # the first and second axis below for each RV so the shape
-        # is what ArviZ expected. 
+        # is what ArviZ expected.
         k:np.swapaxes(v, 1, 0)
         for k, v in mcmc_samples._asdict().items()},
     sample_stats={
@@ -599,7 +599,7 @@ this relationship of observed flipper length on estimated mass is to fit
 a linear regression model, where the mean is *conditionally* modeled as
 a linear combination of other variables
 
-```{math} 
+```{math}
 :label: eq:expanded_regression
 
 \begin{split}
@@ -626,9 +626,9 @@ hyperplane.
 Alternatively we can express Equation {eq}`eq:expanded_regression` using
 matrix notation:
 
-```{math} 
+```{math}
 :label: eq:linear_model_matrix
-\mu = \mathbf{X}\boldsymbol{\beta} 
+\mu = \mathbf{X}\boldsymbol{\beta}
 
 ```
 
@@ -639,7 +639,7 @@ An alternative expression you might have seen in other (non-Bayesian)
 occasions is to rewrite Equation {eq}`eq:expanded_regression` as noisy
 observation of some linear prediction:
 
-```{math} 
+```{math}
 :label: eq:linear_model_enginner
 
 Y = \mathbf{X}\boldsymbol{\beta} + \epsilon,\; \epsilon \sim \mathcal{N}(0, \sigma)
@@ -730,9 +730,9 @@ with pm.Model() as model_adelie_flipper_regression:
     β_0 = pm.Normal("β_0", 0, 4000)
     β_1 = pm.Normal("β_1", 0, 4000)
     μ = pm.Deterministic("μ", β_0 + β_1 * adelie_flipper_length)
-    
+
     mass = pm.Normal("mass", mu=μ, sigma=σ, observed = adelie_mass_obs)
-    
+
     inf_data_adelie_flipper_regression = pm.sample(return_inferencedata=True)
 ```
 
@@ -901,7 +901,7 @@ centers its mean value at zero as shown in Code Block
 :name: flipper_centering
 :caption: flipper_centering
 
-adelie_flipper_length_c = (adelie_flipper_length_obs - 
+adelie_flipper_length_c = (adelie_flipper_length_obs -
                            adelie_flipper_length_obs.mean())
 ```
 
@@ -1013,12 +1013,12 @@ with pm.Model() as model_penguin_mass_categorical:
     β_0 = pm.Normal("β_0", 0, 3000)
     β_1 = pm.Normal("β_1", 0, 3000)
     β_2 = pm.Normal("β_2", 0, 3000)
-    
+
     μ = pm.Deterministic(
         "μ", β_0 + β_1 * adelie_flipper_length_obs + β_2 * sex_obs)
-    
+
     mass = pm.Normal("mass", mu=μ, sigma=σ, observed=adelie_mass_obs)
-    
+
     inf_data_penguin_mass_categorical = pm.sample(
         target_accept=.9, return_inferencedata=True)
 ```
@@ -1056,7 +1056,7 @@ write:
 :name: bambi_categorical
 :caption: bambi_categorical
 
-import bambi as bmb 
+import bambi as bmb
 model = bmb.Model("body_mass_g ~ flipper_length_mm + sex",
                   penguins[adelie_mask])
 trace = model.fit()
@@ -1156,7 +1156,7 @@ model building and inference is shown in Code Block
 
 def gen_jd_flipper_bill_sex(flipper_length, sex, bill_length, dtype=tf.float32):
     flipper_length, sex, bill_length = tf.nest.map_structure(
-        lambda x: tf.constant(x, dtype), 
+        lambda x: tf.constant(x, dtype),
         (flipper_length, sex, bill_length)
     )
 
@@ -1168,8 +1168,8 @@ def gen_jd_flipper_bill_sex(flipper_length, sex, bill_length, dtype=tf.float32):
         β_1 = yield root(tfd.Normal(loc=0, scale=3000, name="beta_1"))
         β_2 = yield root(tfd.Normal(loc=0, scale=3000, name="beta_2"))
         β_3 = yield root(tfd.Normal(loc=0, scale=3000, name="beta_3"))
-        μ = (β_0[..., None] 
-             + β_1[..., None] * flipper_length 
+        μ = (β_0[..., None]
+             + β_1[..., None] * flipper_length
              + β_2[..., None] * sex
              + β_3[..., None] * bill_length
             )
@@ -1278,11 +1278,11 @@ linear function, $\mathbf{X} \mathit{\beta}$, and modify it using an
 inverse link function [^8] $\phi$ as shown in Equation
 {eq}`eq:generalized_linear_model`.
 
-```{math} 
+```{math}
 :label: eq:generalized_linear_model
 \begin{split}
 \mu =& \phi(\mathbf{X} \beta) \\
-Y \sim& \Psi (\mu, \theta)     
+Y \sim& \Psi (\mu, \theta)
 
 \end{split}
 ```
@@ -1317,7 +1317,7 @@ interval. This is handy because now we can map linear functions to the
 range we would expect for a parameter that estimates probability values,
 that must be in the range 0 and 1 by definition.
 
-```{math} 
+```{math}
 :label: eq:logistic
 p = \frac{1}{1+e^{-\mathbf{X}\beta}}
 
@@ -1339,11 +1339,11 @@ prediction in the set ${0,1}$. Let us assume we want our decision
 boundary set at a probability of 0.5. For a model with an intercept and
 one covariate we have:
 
-```{math} 
+```{math}
 \begin{split}
 0.5 &= logistic(\beta_{0} + \beta_{1}*x) \\
-logit(0.5) &= \beta_{0} + \beta_{1}*x \\  
-0 &= \beta_{0} + \beta_{1}*x \\ 
+logit(0.5) &= \beta_{0} + \beta_{1}*x \\
+0 &= \beta_{0} + \beta_{1}*x \\
 x &= -\frac{\beta_{0}}{\beta_{1}} \\
 \end{split}
 ```
@@ -1376,18 +1376,18 @@ species = pd.Categorical(penguins.loc[species_filter, "species"])
 with pm.Model() as model_logistic_penguins_bill_length:
     β_0 = pm.Normal("β_0", mu=0, sigma=10)
     β_1 = pm.Normal("β_1", mu=0, sigma=10)
-    
-    μ = β_0 + pm.math.dot(bill_length_obs, β_1)  
-    
+
+    μ = β_0 + pm.math.dot(bill_length_obs, β_1)
+
     # Application of our sigmoid  link function
     θ = pm.Deterministic("θ", pm.math.sigmoid(μ))
-    
+
     # Useful for plotting the decision boundary later
     bd = pm.Deterministic("bd", -β_0/β_1)
-    
+
     # Note the change in likelihood
     yl = pm.Bernoulli("yl", p=θ, observed=species.codes)
-    
+
     prior_predictive_logistic_penguins_bill_length = pm.sample_prior_predictive()
     trace_logistic_penguins_bill_length = pm.sample(5000, chains=2)
     inf_data_logistic_penguins_bill_length = az.from_pymc3(
@@ -1473,11 +1473,11 @@ mass_obs = penguins.loc[species_filter, "body_mass_g"].values
 with pm.Model() as model_logistic_penguins_mass:
     β_0 = pm.Normal("β_0", mu=0, sigma=10)
     β_1 = pm.Normal("β_1", mu=0, sigma=10)
-    
-    μ = β_0 + pm.math.dot(mass_obs, β_1)  
+
+    μ = β_0 + pm.math.dot(mass_obs, β_1)
     θ = pm.Deterministic("θ", pm.math.sigmoid(μ))
     bd = pm.Deterministic("bd", -β_0/β_1)
-    
+
     yl = pm.Bernoulli("yl", p=θ, observed=species.codes)
 
     inf_data_logistic_penguins_mass = pm.sample(
@@ -1550,11 +1550,11 @@ X = X.values
 with pm.Model() as model_logistic_penguins_bill_length_mass:
     β = pm.Normal("β", mu=0, sigma=20, shape=3)
 
-    μ = pm.math.dot(X, β)  
+    μ = pm.math.dot(X, β)
 
     θ = pm.Deterministic("θ", pm.math.sigmoid(μ))
     bd = pm.Deterministic("bd", -β[0]/β[2] - β[1]/β[2] * X[:,1])
-    
+
     yl = pm.Bernoulli("yl", p=θ, observed=species.codes)
 
     inf_data_logistic_penguins_bill_length_mass = pm.sample(
@@ -1622,7 +1622,7 @@ and now we have a numerical confirmation as well.
 :caption: penguin_model_loo
 
 az.compare({"mass":inf_data_logistic_penguins_mass,
-            "bill": inf_data_logistic_penguins_bill_length, 
+            "bill": inf_data_logistic_penguins_bill_length,
             "mass_bill":inf_data_logistic_penguins_bill_length_mass})
 ```
 
@@ -1725,7 +1725,7 @@ natural log of the odds which is the fraction shown in Equation
 {eq}`eq:logit`. We can rewrite the logistic regression in Equation
 {eq}`eq:logistic` in an alternative form of using the logit.
 
-```{math} 
+```{math}
 :label: eq:logit
 \log \left(\frac{p}{1-p} \right) = \boldsymbol{X} \beta
 
@@ -1753,8 +1753,8 @@ bill_length = 45
 val_1 = β_0 + β_1*bill_length
 val_2 = β_0 + β_1*(bill_length+1)
 
-f"(Class Probability change from 45mm Bill Length to 46mm:
-{(special.expit(val_2) -  special.expit(val_1))*100:.0f}%)"
+f"""(Class Probability change from 45mm Bill Length to 46mm:
+{(special.expit(val_2) -  special.expit(val_1))*100:.0f}%)"""
 ```
 
 ```
@@ -1802,15 +1802,15 @@ with pm.Model() as model_uninformative_prior_sex_ratio:
     β_0 = pm.Normal("β_0", 50, 20)
 
     μ = pm.Deterministic("μ", β_0 + β_1 * x)
-    
+
     ratio = pm.Normal("ratio", mu=μ, sigma=σ, observed=y)
-    
+
     prior_predictive_uninformative_prior_sex_ratio = pm.sample_prior_predictive(
         samples=10000
     )
     trace_uninformative_prior_sex_ratio = pm.sample()
     inf_data_uninformative_prior_sex_ratio = az.from_pymc3(
-        trace=trace_uninformative_prior_sex_ratio, 
+        trace=trace_uninformative_prior_sex_ratio,
         prior=prior_predictive_uninformative_prior_sex_ratio
     )
 ```
@@ -1869,14 +1869,14 @@ possible ratios.
 
 with pm.Model() as model_informative_prior_sex_ratio:
     σ = pm.Exponential("σ", .5)
-    
+
     # Note the now more informative priors
     β_1 = pm.Normal("β_1", 0, .5)
     β_0 = pm.Normal("β_0", 48.5, .5)
 
     μ = pm.Deterministic("μ", β_0 + β_1 * x)
     ratio = pm.Normal("ratio", mu=μ, sigma=σ, observed=y)
-    
+
     prior_predictive_informative_prior_sex_ratio = pm.sample_prior_predictive(
         samples=10000
     )

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -83,6 +83,7 @@ snowballstemmer==2.2.0
 soupsieve==2.3.1
 Sphinx==4.3.2
 sphinx-book-theme==0.1.7
+sphinx-codeautolink==0.8.0
 sphinx-comments==0.0.3
 sphinx-copybutton==0.4.0
 sphinx-external-toc==0.2.3


### PR DESCRIPTION
Some changes regarding code block style, feel free to keep all, some or none.
Overview of changes

* add line numbers to an example where they were referenced
* use code blocks without highlighting for outputs
* add codeautolink so that arviz, numpy, matplotlib and scipy.stats objects used
  within code _blocks_ (no inline) automatically get links to the relevant api page.
  Some notes on this:
  * Haven't checked tf or tfp but it should be possible to set it up too.
  * It won't work with pymc3 though. pymc3 documents objects where they are implemented,
    not where users import them so for this to work automatically you'd
    need to use `pm.distributions.continuous.Normal` instead of pm.Normal` for example.
  * it works with python code blocks only for now, setting it up for jupyter notebooks
    requires a bit more work that I did for arviz and pymc-examples but would have
    to adapt to using `_config.yml` instead of `conf.py`
