### PR TITLE
fix many typos

### DIFF
--- a/Errata.md
+++ b/Errata.md
@@ -9,6 +9,8 @@
 | xvi | For a reference on Python, or how to setup the computation environment needed for this book, go to README.md in Github to understand how to setup a code environment | For a reference on how to setup the computation environment needed for this book, go to README.md in GitHhub. |  |
 | 26 | 1E8. Rerun Code block | 1E8. Rerun Code Block |  |
 | 42 | Plotting the ESS for specifics quantiles `az.plot_ess(., kind="quantiles"`  | Plotting the ESS for specifics quantiles `az.plot_ess(., kind="quantiles"`) | Thanks Juan Orduz |
+| 73 | ...the **thin** line is the interquartile range **from 25% to 75% of the posterior** and the
+**thick** line is the 94% Highest Density Interval | the **thick** line is the interquartile range and the **thin** line is the 94% Highest Density Interval | Thanks Jose Roberto Ayala Solares |
 | 75 | ... is the intercept only regression model **from** | is the intercept only regression model in **Code Block** |  |
 | 183 | ...a backshift operator, also called Lag operator) | ...a backshift operator **(**also called Lag operator) |  |
 | 191 | (footnote) The Stan implementation of SARIMA can be found in https://github.com/asael697/**varstan**. | The Stan implementation of SARIMA can be found in **e.g.,** https://github.com/asael697/**bayesforecast**. |  |
@@ -21,4 +23,6 @@
 | 318 | As you can see, there is a lot of **rooms** for... | As you can see, there is a lot of **room** for... |  |
 | 344 | ...will make the **skweness** independent... | ...will make the **skewness** independent... | Thanks Alihan Zihna |
 | 371 | ...a simple Python implementation in **Code block** | ...simple Python implementation in **Code Block** |  |
+| 376 |  We can see that all these trajectories **when** wrong. We call this kind **these divergences and we can used as diagnostics of the** HMC samplers. | We can see that all these trajectories went wrong. We call this kind **of trajectories divergences and can be used as a diagnostic of** HMC samplers | Thanks Alihan Zihna |
+| 380 | ... if **you** future lab... | ... if **your** future lab... | Thanks Alihan Zihna |
 | 385 | ...more parameters than can be justified by the data.**[2]** | ... more parameters than can be justified by the data. |  |

--- a/Errata.md
+++ b/Errata.md
@@ -9,8 +9,7 @@
 | xvi | For a reference on Python, or how to setup the computation environment needed for this book, go to README.md in Github to understand how to setup a code environment | For a reference on how to setup the computation environment needed for this book, go to README.md in GitHhub. |  |
 | 26 | 1E8. Rerun Code block | 1E8. Rerun Code Block |  |
 | 42 | Plotting the ESS for specifics quantiles `az.plot_ess(., kind="quantiles"`  | Plotting the ESS for specifics quantiles `az.plot_ess(., kind="quantiles"`) | Thanks Juan Orduz |
-| 73 | ...the **thin** line is the interquartile range **from 25% to 75% of the posterior** and the
-**thick** line is the 94% Highest Density Interval | the **thick** line is the interquartile range and the **thin** line is the 94% Highest Density Interval | Thanks Jose Roberto Ayala Solares |
+| 73 | ...the **thin** line is the interquartile range **from 25% to 75% of the posterior** and the **thick** line is the 94% Highest Density Interval | the **thick** line is the interquartile range and the **thin** line is the 94% Highest Density Interval | Thanks Jose Roberto Ayala Solares |
 | 75 | ... is the intercept only regression model **from** | is the intercept only regression model in **Code Block** |  |
 | 183 | ...a backshift operator, also called Lag operator) | ...a backshift operator **(**also called Lag operator) |  |
 | 191 | (footnote) The Stan implementation of SARIMA can be found in https://github.com/asael697/**varstan**. | The Stan implementation of SARIMA can be found in **e.g.,** https://github.com/asael697/**bayesforecast**. |  |

--- a/markdown/chp_03.md
+++ b/markdown/chp_03.md
@@ -309,10 +309,9 @@ az.plot_forest(inf_data_model_penguin_mass_all_species, var_names=["μ"])
 :name: fig:forest_plot_means
 :width: 7.00in
 Forest plot of the mean of mass of each species group in
-`model_penguin_mass_all_species`. Each line represents one chain in the
-sampler, the dot is a point estimate, in this case the mean, the thin
-line is the interquartile range from 25% to 75% of the posterior and the
-thick line is the 94% Highest Density Interval.
+`model_penguin_mass_all_species`.  Each line represents one chain in the sampler, the dot is the
+mean, the thick line is the interquartile range and the thin line is the 94\% Highest Density
+Interval.
 ```
 
 {numref}`fig:forest_plot_means` makes it easier to compare our estimates

--- a/markdown/chp_11.md
+++ b/markdown/chp_11.md
@@ -411,7 +411,7 @@ similar to mathematical proof but they can be more intuitive. Stories
 are also very useful devices to create statistical models, you can think
 about how the data may have been generated, and then try to write that
 down in statistical notation and/or code. We do this, for example, in
-Chapter [9]](chap9) with our flight delay example.
+Chapter [9](chap9) with our flight delay example.
 
 (discrete-uniform-distribution)=
 
@@ -2713,7 +2713,7 @@ distributed farther and farther away from the mode of that Gaussian.
 
 There a a myriad of methods to compute the posterior. If we exclude the
 exact analytical solutions we already discussed in Chapter
-[1]](chap1) when we discussed conjugate priors, we can classify
+[1](chap1) when we discussed conjugate priors, we can classify
 inference methods into 3 large groups:
 
 1.  Deterministic integration methods, that we have not yet seen in the
@@ -3189,9 +3189,8 @@ distribution we are trying to explore.
 :name: fig:funnel_leapgrog
 :width: 8.00in
 Three HMC trajectories *around* a 2D Neal's funnel. This kind geometry
-turns up in centered hierarchical models. We can see that all these
-trajectories when wrong. We call this kind these divergences and we can
-used as diagnostics of the HMC samplers.
+turns up in centered hierarchical models. We can see that all these trajectories went wrong.
+We call this kind of trajectories divergences and can be used as a diagnostic of HMC samplers.
 ```
 
 Both Figures {numref}`fig:normal_leapgrog` and
@@ -3463,7 +3462,7 @@ community you want to work with and what language they use. One of the
 authors of this book lives in Southern California, so knowing English,
 and a bit of Spanish makes a lot of sense, because with those two he
 could communicate in common situations. It is the same with programming
-languages, if you future lab group uses R then learning R is a good
+languages, if your future lab group uses R then learning R is a good
 idea.
 
 Computational purists may exclaim that some languages are faster than


### PR DESCRIPTION
closes #95
closes #96 
This also fix a couple more typos generated when converting to .md