### PR TITLE
Match y value in `plot_separation` to name assigned to distributions in previous cells

### DIFF
--- a/markdown/chp_03.md
+++ b/markdown/chp_03.md
@@ -1595,7 +1595,7 @@ models = {"bill": inf_data_logistic_penguins_bill_length,
 
 _, axes = plt.subplots(3, 1, figsize=(12, 4), sharey=True)
 for (label, model), ax in zip(models.items(), axes):
-    az.plot_separation(model, "p", ax=ax, color="C4")
+    az.plot_separation(model, "yl", ax=ax, color="C4")
     ax.set_title(label)
 ```
 


### PR DESCRIPTION
Currently `plot_separation` has `y="p"`—which doesn't match the names assigned in the preceding three models. Updated to `y="yl"`, which matches the names used in the chapter.

---

Enjoying the book so far! Thanks for sharing it!
