### PR TITLE
Replace salad with sandwhich in list of stable categories in hierarchical modeling

### DIFF
--- a/Errata.md
+++ b/Errata.md
@@ -52,7 +52,8 @@
 | 98 | ...from Adelie or Chinstrap **penguinsthe**... | ...from Adelie or Chinstrap **penguins the**... | Thanks Sebastian |
 | 101 | Given these choices we can write our model in Code Block 3.30**)**... | Given these choices we can write our model in Code Block 3.30 | Thanks Sebastian |
 | 101 | This is not a fully uninformative **priors**... | This is not a fully uninformative **prior**... | Thanks Sebastian |
-| 102 | ...fall into bounds that more reasonable... | ...fall into bounds that **are** more reasonable... | Thanks Sebastian |
+| 102 | ...fall into bounds that more reasonable... | ...fall into bounds that **are** more reasonable... | Thanks @paw-lu |
+| 130 | ...the estimates of the pizza and salad categories... | ...the estimates of the pizza and **sandwich** categories... | Thanks Sebastian |
 | 133 | (In Code Block 9.1) inside function `gen_hierarchical_salad_sales` all reference to `hierarchical_salad_df` | should be `input_df` | Thanks Alihan Zihna |
 | 183 | ...a backshift operator, also called Lag operator) | ...a backshift operator **(**also called Lag operator) |  |
 | 191 | (footnote) The Stan implementation of SARIMA can be found in https://github.com/asael697/**varstan**. | The Stan implementation of SARIMA can be found in **e.g.,** https://github.com/asael697/**bayesforecast**. |  |

--- a/Errata.md
+++ b/Errata.md
@@ -52,8 +52,8 @@
 | 98 | ...from Adelie or Chinstrap **penguinsthe**... | ...from Adelie or Chinstrap **penguins the**... | Thanks Sebastian |
 | 101 | Given these choices we can write our model in Code Block 3.30**)**... | Given these choices we can write our model in Code Block 3.30 | Thanks Sebastian |
 | 101 | This is not a fully uninformative **priors**... | This is not a fully uninformative **prior**... | Thanks Sebastian |
-| 102 | ...fall into bounds that more reasonable... | ...fall into bounds that **are** more reasonable... | Thanks @paw-lu |
-| 130 | ...the estimates of the pizza and salad categories... | ...the estimates of the pizza and **sandwich** categories... | Thanks Sebastian |
+| 102 | ...fall into bounds that more reasonable... | ...fall into bounds that **are** more reasonable... | Thanks Sebastian |
+| 130 | ...the estimates of the pizza and salad categories... | ...the estimates of the pizza and **sandwich** categories... | Thanks  @paw-lu |
 | 133 | (In Code Block 9.1) inside function `gen_hierarchical_salad_sales` all reference to `hierarchical_salad_df` | should be `input_df` | Thanks Alihan Zihna |
 | 183 | ...a backshift operator, also called Lag operator) | ...a backshift operator **(**also called Lag operator) |  |
 | 191 | (footnote) The Stan implementation of SARIMA can be found in https://github.com/asael697/**varstan**. | The Stan implementation of SARIMA can be found in **e.g.,** https://github.com/asael697/**bayesforecast**. |  |

--- a/markdown/chp_04.md
+++ b/markdown/chp_04.md
@@ -1069,7 +1069,7 @@ in {numref}`tab:unpooled_sales`. In the unpooled estimate the mean of
 the $\sigma$ estimate for salads is 21.3, whereas in the hierarchical
 estimate the mean of the same parameter estimate is now 25.5, and has
 been "pulled\" up by the means of the pizza and sandwiches category.
-Moreover, the estimates of the pizza and salad categories in the
+Moreover, the estimates of the pizza and sandwich categories in the
 hierarchical category, while regressed towards the mean slightly, remain
 largely the same as the unpooled estimates. Note how the estimates of each
 sigma are distinctly different from each other. Given that our observed data


### PR DESCRIPTION
> In the unpooled estimate the mean of the $\sigma$ estimate for salads is 21.3, whereas in the hierarchical estimate the mean of the same parameter estimate is now 25.5, and has been “pulled” up by the means of the pizza and sandwiches category. Moreover, the estimates of the pizza and salad categories in the hierarchical category, while regressed towards the mean slightly, remain largely the same as the unpooled estimates.

In the Hierarchical models section, the text lists salad as a category notably influenced by the hyperprior, then immediately lists salads as a stable category lightly effected by the hyperprior. I think this is meant to be sandwhiches instead of salads—since it's much more stable.
