### PR TITLE
Remove uneeded underscore escape

### DIFF
--- a/markdown/chp_04.md
+++ b/markdown/chp_04.md
@@ -1362,8 +1362,8 @@ multiple samples down to the 0 value on the x-axis.
 \begin{split}
 \beta_{\mu h} \sim& \mathcal{N} \\
 \beta_{\sigma h} \sim& \mathcal{HN} \\
-\beta_\text{m\_offset} \sim& \mathcal{N}(0,1) \\
-\beta_m =& \overbrace{\beta_{\mu h} + \beta_\text{m\_offset}*\beta_{\sigma h}}^{\text{Non-centered}}  \\
+\beta_\text{m_offset} \sim& \mathcal{N}(0,1) \\
+\beta_m =& \overbrace{\beta_{\mu h} + \beta_\text{m_offset}*\beta_{\sigma h}}^{\text{Non-centered}}  \\
 \sigma_{h} \sim& \mathcal{HN} \\
 \sigma_{m} \sim& \mathcal{HN}(\sigma_{h}) \\
 Y \sim& \mathcal{N}(\beta_{m} * X_m,\sigma_{m})


### PR DESCRIPTION
[This seems to only effect the web version of the book.](https://bayesiancomputationbook.com/markdown/chp_04.html#equation-eq-noncentered-hierarchical-regression) The purchased copy looks fine. This may actually cause the rendered pdf or ebook to render incorrectly depending on what is being used to render the $\LaTeX$ equations!

### Screenshot of **web version**

<img width="295" alt="Screen Shot 2022-05-21 at 6 45 13 PM" src="https://user-images.githubusercontent.com/30049606/169674926-10ab39af-4e74-4888-a6df-97db43bf3e35.png">