### PR TITLE
Revert "Update Kalman Filter equation"

### DIFF
--- a/Errata.md
+++ b/Errata.md
@@ -61,7 +61,6 @@
 | 156 | Fig 5.7 y_labels is **count_std** | should be **count_normalized** | Thanks Paulo S. Costa |
 | 183 | ...a backshift operator, also called Lag operator) | ...a backshift operator **(**also called Lag operator) |  |
 | 191 | (footnote) The Stan implementation of SARIMA can be found in https://github.com/asael697/**varstan**. | The Stan implementation of SARIMA can be found in **e.g.,** https://github.com/asael697/**bayesforecast**. |  |
-| 196 | Equation (6.15) last line  | $\mathbf{P}_{t \mid t} & = \mathbf{P}_{t \mid t-1} - \mathbf{K}_t \mathbf{S}_t \mathbf{P}_{t \mid t-1}$ |  |
 | 197 | we can apply the Kalman filter to **to** obtain**s** the posterior | we can apply the Kalman filter to obtain the posterior |  |
 | 261 | Some **commons** elements to all Bayesian analyses, | Some **common** elements to all Bayesian analyses, | Thanks Ero Carrera |
 | 262 | (In Figure 9.1.) Model **Compasion** | Model **Comparison** | Thanks Ben Vincent |

--- a/markdown/chp_06.md
+++ b/markdown/chp_06.md
@@ -1450,7 +1450,7 @@ and update steps:
         \mathbf{S}_t & = \mathbf{H}_t \mathbf{P}_{t \mid t-1} \mathbf{H}_t^T + \mathbf{R}_t \\
         \mathbf{K}_t & = \mathbf{P}_{t \mid t-1} \mathbf{H}_t^T \mathbf{S}_t^{-1} \\
         m_{t \mid t} & = m_{t \mid t-1} + \mathbf{K}_t z_t \\
-        \mathbf{P}_{t \mid t} & = \mathbf{P}_{t \mid t-1} - \mathbf{K}_t \mathbf{S}_t \mathbf{P}_{t \mid t-1}
+        \mathbf{P}_{t \mid t} & = \mathbf{P}_{t \mid t-1} - \mathbf{K}_t \mathbf{S}_t \mathbf{K}_t^T
         \end{split}
     ```
 


### PR DESCRIPTION
Reverts BayesianModelingandComputationInPython/BookCode_Edition1#168

OK I had myself confused... Actually what's written in the book is correct
![image](https://user-images.githubusercontent.com/12952641/173225199-f96ba236-31c3-4358-908a-c97412d7646f.png)

But wikipedia and some other book write is as 
![image](https://user-images.githubusercontent.com/12952641/173225208-0f290dbe-67f0-4574-b2f7-774a35900a9b.png)
