### PR TITLE
Fix build errors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,7 +31,7 @@ sphinx:
       html_favicon: "favicon.ico"
       intersphinx_mapping:
         arviz:
-          - https://arviz-devs.github.io/arviz/
+          - https://python.arviz.org/en/latest/
           - null
         numpy:
           - https://numpy.org/doc/stable


### PR DESCRIPTION
Thank you so much for sharing this work in an open forum!

This PR is in relation to #226.

I ran into a few build errors while building via `build.sh`:
- Broken arviz intersphinx mapping link
- Typo in `notebooks_update/chp_06.ipynb`

These may be intentional or my approaches could be off, but I wanted to share what helped me in case it's useful. Thanks!

